### PR TITLE
Fix the mobile version of the js-example

### DIFF
--- a/js-example/src/Components/Mnemonic.purs
+++ b/js-example/src/Components/Mnemonic.purs
@@ -119,9 +119,6 @@ mnemonicSpec mnemonicSize canGenerate = T.simpleSpec performAction render
 placeholderPhrase :: String
 placeholderPhrase = "abandon ability able about above absent absorb abstract absurd abuse access accident"
 
-cardanoMnemonicSize :: Int
-cardanoMnemonicSize = 12
-
 englishWords :: Array String
 englishWords =
     [ "abandon"

--- a/js-example/src/Components/Page.purs
+++ b/js-example/src/Components/Page.purs
@@ -247,13 +247,13 @@ page = container $ fold
     listActions = T.simpleSpec performAction T.defaultRender
       where
       performAction :: T.PerformAction eff PageState props PageAction
-      performAction (MnemonicAction (NewMnemonic m))     _ _ = void $ T.modifyState \st ->
-        updatePageState $ st { mnemonic = m }
-      performAction (PassphraseAction (NewPassphrase p)) _ _ = void $ T.modifyState \st ->
+      performAction (MnemonicAction _)    _ _ = void $ T.modifyState \st ->
+        updatePageState st
+      performAction (PassphraseAction _) _ _ = void $ T.modifyState \st ->
         updatePageState $ st {
             scramble = case mnemonicToEntropy st.mnemonic.mnemonic of
                 Nothing -> initialMnemonic
-                Just e -> case scramble e p.passphrase of
+                Just e -> case scramble e st.passphrase.passphrase of
                     Nothing -> initialMnemonic
                     Just s  -> case entropyToMnemonic s of
                         Nothing -> initialMnemonic


### PR DESCRIPTION
I have fixed the issue on mobile when entering the mnemonic and passphrase. Now it is checked dynamically so Executive can now check it out on their phones.