### PR TITLE
[DDW-174] also run js test suite on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
     - rust: stable
     - rust: beta
     - rust: nightly
+    - rust: nightly
+      env: NODE_JS_GLUE
       before_script:
         - rustup target add wasm32-unknown-unknown --toolchain nightly
         - nvm install 8.2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,18 @@ rust:
   - stable
   - beta
   - nightly
-#matrix:
-#  allow_failures:
-#    - rust: nightly
-before_install:
-  - nvm install 8.2.1
-before_script:
-  - npm install
 script:
   - cargo build --verbose --all
   - cargo test --verbose --all
-  - ./build
-  - npm run test
+matrix:
+#  allow_failures:
+#    - rust: nightly
+  include:
+    - rust: nightly
+      before_script:
+        - rustup target add wasm32-unknown-unknown --toolchain nightly
+        - nvm install 8.2.1
+        - npm install
+        - ./build
+      script:
+        - npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ rust:
 #matrix:
 #  allow_failures:
 #    - rust: nightly
+before_install:
+  - nvm install 8.2.1
+before_script:
+  - npm install
 script:
   - cargo build --verbose --all
   - cargo test --verbose --all
+  - ./build
+  - npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: rust
 cache: cargo
-rust:
-  - stable
-  - beta
-  - nightly
 script:
   - cargo build --verbose --all
   - cargo test --verbose --all
@@ -11,6 +7,8 @@ matrix:
 #  allow_failures:
 #    - rust: nightly
   include:
+    - rust: stable
+    - rust: beta
     - rust: nightly
       before_script:
         - rustup target add wasm32-unknown-unknown --toolchain nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ script:
   - cargo build --verbose --all
   - cargo test --verbose --all
 matrix:
-#  allow_failures:
-#    - rust: nightly
   include:
     - rust: stable
     - rust: beta


### PR DESCRIPTION
The target of this PR is to make node / JS test suite run on travis additionally to the current rust tests.