### PR TITLE
Sign and verify transactions

### DIFF
--- a/wallet-crypto/src/hdwallet.rs
+++ b/wallet-crypto/src/hdwallet.rs
@@ -336,6 +336,19 @@ impl<T> fmt::Debug for Signature<T> {
 impl<T> AsRef<[u8]> for Signature<T> {
     fn as_ref(&self) -> &[u8] { &self.bytes }
 }
+impl<T> cbor::CborValue for Signature<T> {
+    fn encode(&self) -> cbor::Value { cbor::Value::Bytes(cbor::Bytes::from_slice(self.as_ref())) }
+    fn decode(value: cbor::Value) -> cbor::Result<Self> {
+        value.bytes().and_then(|bytes| {
+            match Signature::from_slice(bytes.as_ref()) {
+                Some(digest) => Ok(digest),
+                None         => {
+                    cbor::Result::bytes(bytes, cbor::Error::InvalidSize(SIGNATURE_SIZE))
+                }
+            }
+        }).embed("while decoding Signature<T>")
+    }
+}
 
 pub type ChainCode = [u8; CHAIN_CODE_SIZE];
 

--- a/wallet-crypto/src/tx.rs
+++ b/wallet-crypto/src/tx.rs
@@ -8,7 +8,7 @@ use rcw::blake2b::Blake2b;
 use cbor;
 use cbor::{ExtendedResult};
 
-use hdwallet::{Signature, XPub};
+use hdwallet::{Signature, XPub, XPrv};
 use address::ExtendedAddr;
 use merkle;
 
@@ -130,12 +130,64 @@ type RedeemerScript = TODO;
 type RedeemPublicKey = TODO;
 type RedeemSignature = TODO;
 
-enum TxInWitness {
+#[derive(Debug, PartialEq, Eq)]
+pub enum TxInWitness {
     /// signature of the `TxIn` with the associated `XPub`
     /// the `XPub` is the public key set in the AddrSpendingData
     PkWitness(XPub, Signature<Tx>),
     ScriptWitness(ValidatorScript, RedeemerScript),
     RedeemWitness(RedeemPublicKey, RedeemSignature),
+}
+impl TxInWitness {
+    pub fn new(key: &XPrv, tx: &Tx) -> Self {
+        let txid = cbor::encode_to_cbor(&tx.id()).unwrap();
+
+        let mut vec = vec![ 0x01 // this is the tag for TxSignature
+                          , 0x1a, 0x2d, 0x96, 0x4a, 0x09 // this is the magic (serialised in cbor...)
+                          ];
+        vec.extend_from_slice(&txid);
+        TxInWitness::PkWitness(key.public(), key.sign(&vec))
+    }
+}
+impl cbor::CborValue for TxInWitness {
+    fn encode(&self) -> cbor::Value {
+        let (i, bytes) = match self {
+            &TxInWitness::PkWitness(ref pk, ref sig) => {
+                let v = cbor::Value::Array(
+                    vec![ cbor::CborValue::encode(pk)
+                        , cbor::CborValue::encode(sig)
+                        ]
+                );
+                (0u64, cbor::encode_to_cbor(&v).unwrap())
+            },
+            &TxInWitness::ScriptWitness(_, _) => { unimplemented!() },
+            &TxInWitness::RedeemWitness(_, _) => { unimplemented!() },
+        };
+        cbor::Value::Array(
+            vec![ cbor::CborValue::encode(&i)
+                , cbor::Value::Tag(24, Box::new(cbor::Value::Bytes(cbor::Bytes::new(bytes))))
+                ]
+        )
+    }
+    fn decode(value: cbor::Value) -> cbor::Result<Self> {
+        value.array().and_then(|sum_type| {
+            let (sum_type, v) = cbor::array_decode_elem(sum_type, 0).embed("sum_type's id")?;
+            match v {
+                0u64 => {
+                    let (sum_type, tag) : (Vec<cbor::Value>, cbor::Value) = cbor::array_decode_elem(sum_type, 0).embed("sum_type's value")?;
+                    if !sum_type.is_empty() { return cbor::Result::array(sum_type, cbor::Error::UnparsedValues); }
+                    tag.tag().and_then(|(t, v)| {
+                        if t != 24 { return cbor::Result::tag(t, v, cbor::Error::InvalidTag(t)); }
+                        (*v).bytes()
+                    }).and_then(|bytes| {
+                        let (pk, sig) = cbor::decode_from_cbor(bytes.as_ref())?;
+                        Ok(TxInWitness::PkWitness(pk, sig))
+                    }).embed("while decoding `TxInWitness::PkWitness`")
+                },
+                _ => { unimplemented!() }
+            }
+        }).embed("While decoding TxInWitness")
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -185,6 +237,10 @@ impl Tx {
     pub fn new_with(ins: LinkedList<TxIn>, outs: LinkedList<TxOut>) -> Self {
         Tx { inputs: ins, outputs: outs }
     }
+    pub fn id(&self) -> TxId {
+        let buf = cbor::encode_to_cbor(self).expect("to cbor-encode a Tx in a vector in memory");
+        TxId::new(&buf)
+    }
     pub fn add_input(&mut self, i: TxIn) {
         self.inputs.push_back(i)
     }
@@ -233,11 +289,18 @@ mod tests {
     use hdwallet;
     use cbor;
 
+    const SEED: [u8;hdwallet::SEED_SIZE] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
+
+    const DERIVATION_PATH: &'static [u8] = &[1,2,3,4,5];
+
     // CBOR encoded TxOut
     const TX_OUT: &'static [u8] = &[0x82, 0x82, 0xd8, 0x18, 0x58, 0x29, 0x83, 0x58, 0x1c, 0x83, 0xee, 0xa1, 0xb5, 0xec, 0x8e, 0x80, 0x26, 0x65, 0x81, 0x46, 0x4a, 0xee, 0x0e, 0x2d, 0x6a, 0x45, 0xfd, 0x6d, 0x7b, 0x9e, 0x1a, 0x98, 0x3a, 0x50, 0x48, 0xcd, 0x15, 0xa1, 0x01, 0x46, 0x45, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00, 0x1a, 0x9d, 0x45, 0x88, 0x4a, 0x18, 0x2a];
     const TX_IN:  &'static [u8] = &[0x82, 0x00, 0xd8, 0x18, 0x58, 0x26, 0x82, 0x58, 0x20, 0xaa, 0xd7, 0x8a, 0x13, 0xb5, 0x0a, 0x01, 0x4a, 0x24, 0x63, 0x3c, 0x7d, 0x44, 0xfd, 0x8f, 0x8d, 0x18, 0xf6, 0x7b, 0xbb, 0x3f, 0xa9, 0xcb, 0xce, 0xdf, 0x83, 0x4a, 0xc8, 0x99, 0x75, 0x9d, 0xcd, 0x19, 0x02, 0x9a];
 
     const TX: &'static [u8] = &[0x83, 0x9f, 0x82, 0x00, 0xd8, 0x18, 0x58, 0x26, 0x82, 0x58, 0x20, 0xaa, 0xd7, 0x8a, 0x13, 0xb5, 0x0a, 0x01, 0x4a, 0x24, 0x63, 0x3c, 0x7d, 0x44, 0xfd, 0x8f, 0x8d, 0x18, 0xf6, 0x7b, 0xbb, 0x3f, 0xa9, 0xcb, 0xce, 0xdf, 0x83, 0x4a, 0xc8, 0x99, 0x75, 0x9d, 0xcd, 0x19, 0x02, 0x9a, 0xff, 0x9f, 0x82, 0x82, 0xd8, 0x18, 0x58, 0x29, 0x83, 0x58, 0x1c, 0x83, 0xee, 0xa1, 0xb5, 0xec, 0x8e, 0x80, 0x26, 0x65, 0x81, 0x46, 0x4a, 0xee, 0x0e, 0x2d, 0x6a, 0x45, 0xfd, 0x6d, 0x7b, 0x9e, 0x1a, 0x98, 0x3a, 0x50, 0x48, 0xcd, 0x15, 0xa1, 0x01, 0x46, 0x45, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00, 0x1a, 0x9d, 0x45, 0x88, 0x4a, 0x18, 0x2a, 0xff, 0xa0];
+
+    const TX_IN_WITNESS: &'static [u8] = &[0x82, 0x00, 0xd8, 0x18, 0x58, 0x85, 0x82, 0x58, 0x40, 0x1c, 0x0c, 0x3a, 0xe1, 0x82, 0x5e, 0x90, 0xb6, 0xdd, 0xda, 0x3f, 0x40, 0xa1, 0x22, 0xc0, 0x07, 0xe1, 0x00, 0x8e, 0x83, 0xb2, 0xe1, 0x02, 0xc1, 0x42, 0xba, 0xef, 0xb7, 0x21, 0xd7, 0x2c, 0x1a, 0x5d, 0x36, 0x61, 0xde, 0xb9, 0x06, 0x4f, 0x2d, 0x0e, 0x03, 0xfe, 0x85, 0xd6, 0x80, 0x70, 0xb2, 0xfe, 0x33, 0xb4, 0x91, 0x60, 0x59, 0x65, 0x8e, 0x28, 0xac, 0x7f, 0x7f, 0x91, 0xca, 0x4b, 0x12, 0x58, 0x40, 0x9d, 0x6d, 0x91, 0x1e, 0x58, 0x8d, 0xd4, 0xfb, 0x77, 0xcb, 0x80, 0xc2, 0xc6, 0xad, 0xbc, 0x2b, 0x94, 0x2b, 0xce, 0xa5, 0xd8, 0xa0, 0x39, 0x22, 0x0d, 0xdc, 0xd2, 0x35, 0xcb, 0x75, 0x86, 0x2c, 0x0c, 0x95, 0xf6, 0x2b, 0xa1, 0x11, 0xe5, 0x7d, 0x7c, 0x1a, 0x22, 0x1c, 0xf5, 0x13, 0x3e, 0x44, 0x12, 0x88, 0x32, 0xc1, 0x49, 0x35, 0x4d, 0x1e, 0x57, 0xb6, 0x80, 0xfe, 0x57, 0x2d, 0x76, 0x0c];
+
     const BLOCK: &'static [u8] = &[ /* TODO: insert Block here */ ];
 
     #[test]
@@ -298,10 +361,10 @@ mod tests {
         let txid = TxId::new(&[0;32]);
         let txin = TxIn::new(txid, 666);
 
-        let seed = hdwallet::Seed::from_bytes([0;hdwallet::SEED_SIZE]);
+        let seed = hdwallet::Seed::from_bytes(SEED);
         let sk = hdwallet::XPrv::generate_from_seed(&seed);
         let pk = sk.public();
-        let hdap = hdpayload::HDAddressPayload::from_vec(vec![1,2,3,4,5]);
+        let hdap = hdpayload::HDAddressPayload::from_bytes(DERIVATION_PATH);
         let addr_type = address::AddrType::ATPubKey;
         let sd = address::SpendingData::PubKeyASD(pk.clone());
         let attrs = address::Attributes::new_single_key(&pk, Some(hdap));
@@ -314,5 +377,28 @@ mod tests {
         tx.add_output(txout);
 
         assert!(cbor::hs::encode_decode(&tx));
+    }
+
+    #[test]
+    fn txinwitness_decode() {
+        let txinwitness : TxInWitness = cbor::decode_from_cbor(TX_IN_WITNESS).expect("to decode a `TxInWitness`");
+        let tx : Tx = cbor::decode_from_cbor(TX).expect("to decode a `Tx`");
+
+        let seed = hdwallet::Seed::from_bytes(SEED);
+        let sk = hdwallet::XPrv::generate_from_seed(&seed);
+
+        assert!(txinwitness == TxInWitness::new(&sk, &tx));
+    }
+
+    #[test]
+    fn txinwitness_encode_decode() {
+        let tx : Tx = cbor::decode_from_cbor(TX).expect("to decode a `Tx`");
+
+        let seed = hdwallet::Seed::from_bytes(SEED);
+        let sk = hdwallet::XPrv::generate_from_seed(&seed);
+
+        let txinwitness = TxInWitness::new(&sk, &tx);
+
+        assert!(cbor::hs::encode_decode(&txinwitness));
     }
 }

--- a/wallet-crypto/src/tx.rs
+++ b/wallet-crypto/src/tx.rs
@@ -291,7 +291,7 @@ mod tests {
 
     const SEED: [u8;hdwallet::SEED_SIZE] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
 
-    const DERIVATION_PATH: &'static [u8] = &[1,2,3,4,5];
+    const HDPAYLOAD: &'static [u8] = &[1,2,3,4,5];
 
     // CBOR encoded TxOut
     const TX_OUT: &'static [u8] = &[0x82, 0x82, 0xd8, 0x18, 0x58, 0x29, 0x83, 0x58, 0x1c, 0x83, 0xee, 0xa1, 0xb5, 0xec, 0x8e, 0x80, 0x26, 0x65, 0x81, 0x46, 0x4a, 0xee, 0x0e, 0x2d, 0x6a, 0x45, 0xfd, 0x6d, 0x7b, 0x9e, 0x1a, 0x98, 0x3a, 0x50, 0x48, 0xcd, 0x15, 0xa1, 0x01, 0x46, 0x45, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00, 0x1a, 0x9d, 0x45, 0x88, 0x4a, 0x18, 0x2a];
@@ -307,7 +307,7 @@ mod tests {
     fn txout_decode() {
         let txout : TxOut = cbor::decode_from_cbor(TX_OUT).unwrap();
 
-        let hdap = hdpayload::HDAddressPayload::from_vec(vec![1,2,3,4,5]);
+        let hdap = hdpayload::HDAddressPayload::from_bytes(HDPAYLOAD);
         assert_eq!(Coin::new(42).unwrap(), txout.value);
         assert_eq!(address::AddrType::ATPubKey, txout.address.addr_type);
         assert_eq!(address::StakeDistribution::new_bootstrap_era(), txout.address.attributes.stake_distribution);
@@ -316,10 +316,10 @@ mod tests {
 
     #[test]
     fn txout_encode_decode() {
-        let seed = hdwallet::Seed::from_bytes([0;hdwallet::SEED_SIZE]);
+        let seed = hdwallet::Seed::from_bytes(SEED);
         let sk = hdwallet::XPrv::generate_from_seed(&seed);
         let pk = sk.public();
-        let hdap = hdpayload::HDAddressPayload::from_vec(vec![1,2,3,4,5]);
+        let hdap = hdpayload::HDAddressPayload::from_bytes(HDPAYLOAD);
         let addr_type = address::AddrType::ATPubKey;
         let sd = address::SpendingData::PubKeyASD(pk.clone());
         let attrs = address::Attributes::new_single_key(&pk, Some(hdap));
@@ -364,7 +364,7 @@ mod tests {
         let seed = hdwallet::Seed::from_bytes(SEED);
         let sk = hdwallet::XPrv::generate_from_seed(&seed);
         let pk = sk.public();
-        let hdap = hdpayload::HDAddressPayload::from_bytes(DERIVATION_PATH);
+        let hdap = hdpayload::HDAddressPayload::from_bytes(HDPAYLOAD);
         let addr_type = address::AddrType::ATPubKey;
         let sd = address::SpendingData::PubKeyASD(pk.clone());
         let attrs = address::Attributes::new_single_key(&pk, Some(hdap));

--- a/wallet-crypto/src/tx.rs
+++ b/wallet-crypto/src/tx.rs
@@ -212,7 +212,7 @@ impl cbor::CborValue for TxIn {
             let (sum_type, v) = cbor::array_decode_elem(sum_type, 0).embed("sum_type id")?;
             if v != 0u64 { return cbor::Result::array(sum_type, cbor::Error::InvalidSumtype(v)); }
             let (sum_type, tag) : (Vec<cbor::Value>, cbor::Value) = cbor::array_decode_elem(sum_type, 0).embed("sum_type's value")?;
-            if sum_type.len() > 2 { return cbor::Result::array(sum_type, cbor::Error::UnparsedValues); }
+            if !sum_type.is_empty() { return cbor::Result::array(sum_type, cbor::Error::UnparsedValues); }
             tag.tag().and_then(|(t, v)| {
                 if t != 24 { return cbor::Result::tag(t, v, cbor::Error::InvalidTag(t)); }
                 (*v).bytes()


### PR DESCRIPTION
This adds the tooling to sign and verify a transaction (i.e. create a `TxInWitness`).

closes #26 