### PR TITLE
prepare npm release 0.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-cardano-crypto",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rust-cardano-crypto",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Cardano crypto implemented in Rust and transpiled to WebAssembly",
   "main": "./dist/index.js",
   "scripts": {


### PR DESCRIPTION
bump minor version as there is no change of the current API, only additions that are non breaking changes.

closes #31 