### PR TITLE
General configuration (i.e.: protocol magic)

### DIFF
--- a/js/Config.js
+++ b/js/Config.js
@@ -1,0 +1,7 @@
+export const defaultConfig = () => {
+  return { protocol_magic: 764824073 };
+};
+
+export default {
+  defaultConfig: defaultConfig
+};

--- a/js/Tx.js
+++ b/js/Tx.js
@@ -116,19 +116,25 @@ export const addOutput = (module, tx, txout) => {
  * Sign the given tx, this function returns the signature, not the TxInWitness
  *
  * @param module - the WASM module that is used for crypto operations
+ * @param config - the configuration
  * @param tx     - the transaction to add the given TxOut
  * @param xprv   - the extended private key to sign the transaction with
  * @returns {*} - the signature
  */
-export const sign = (module, tx, xprv) => {
+export const sign = (module, config, tx, xprv) => {
+        const config_str   = JSON.stringify(config);
+        const config_array = iconv.encode(config_str, 'utf8');
+
         const buftx = newArray(module, tx);
         const bufxprv = newArray(module, xprv);
+        const bufcfg  = newArray(module, config_array);
         const bufsig = newArray0(module, 64);
 
-        module.wallet_tx_sign(bufxprv, buftx, tx.length, bufsig);
+        module.wallet_tx_sign(bufcfg, config_array.length, bufxprv, buftx, tx.length, bufsig);
         let result = copyArray(module, bufsig, 64);
 
         module.dealloc(bufsig);
+        module.dealloc(bufcfg);
         module.dealloc(bufxprv);
         module.dealloc(buftx);
 

--- a/js/Tx.js
+++ b/js/Tx.js
@@ -145,19 +145,25 @@ export const sign = (module, config, tx, xprv) => {
  * Verify the given signature of a tx
  *
  * @param module  - the WASM module that is used for crypto operations
+ * @param config  - the configuration
  * @param tx      - the transaction to add the given TxOut
  * @param xpub    - the extended private key to sign the transaction with
  * @param signature - the signature to verify
  * @returns {*}   - true or false
  */
-export const verify = (module, tx, xpub, signature) => {
+export const verify = (module, config, tx, xpub, signature) => {
+        const config_str   = JSON.stringify(config);
+        const config_array = iconv.encode(config_str, 'utf8');
+
         const buftx = newArray(module, tx);
         const bufxpub = newArray(module, xpub);
+        const bufcfg  = newArray(module, config_array);
         const bufsig  = newArray(module, signature);
 
-        let result = module.wallet_tx_verify(bufxpub, buftx, tx.length, bufsig);
+        let result = module.wallet_tx_verify(bufcfg, config_array.length, bufxpub, buftx, tx.length, bufsig);
 
         module.dealloc(bufsig);
+        module.dealloc(bufcfg);
         module.dealloc(bufxpub);
         module.dealloc(buftx);
 

--- a/js/index.js
+++ b/js/index.js
@@ -4,6 +4,7 @@ import RustModule, {loadRustModule} from './RustModule.js';
 import Blake2b from './Blake2b.js';
 import Payload from './Payload.js';
 import Tx from './Tx.js';
+import Config from './Config.js';
 
 module.exports = {
   Payload,
@@ -13,4 +14,5 @@ module.exports = {
   loadRustModule,
   Blake2b,
   Tx,
+  Config,
 };

--- a/js/tests/transaction.js
+++ b/js/tests/transaction.js
@@ -50,7 +50,7 @@ let mkTest = (i) => {
                 .deep.equal(signature);
         });
         it('verify a TX signature', function() {
-            expect(CardanoCrypto.Tx.verify(tx, xpub, signature))
+            expect(CardanoCrypto.Tx.verify(cfg, tx, xpub, signature))
                 .equal(true);
         });
     });

--- a/js/tests/transaction.js
+++ b/js/tests/transaction.js
@@ -25,6 +25,7 @@ const TEST_VECTORS = [
 
 let mkTest = (i) => {
     const { txid, index, txin, address, amount, txout, tx, xprv, xpub, signature} = TEST_VECTORS[i];
+    const cfg = CardanoCrypto.Config.defaultConfig();
 
     describe('Test ' + i, function() {
         it('create a TxIn', function() {
@@ -45,7 +46,7 @@ let mkTest = (i) => {
         });
 
         it('sign a Tx', function() {
-            expect(CardanoCrypto.Tx.sign(tx, xprv))
+            expect(CardanoCrypto.Tx.sign(cfg, tx, xprv))
                 .deep.equal(signature);
         });
         it('verify a TX signature', function() {

--- a/wallet-crypto/src/config.rs
+++ b/wallet-crypto/src/config.rs
@@ -1,0 +1,54 @@
+//! there are some settings that need to be set in order to guarantee
+//! operability with the appropriate network or different option.
+//!
+
+use cbor;
+
+/// this is the protocol magic number
+///
+/// it is meant to be used on some places in order to guarantee
+/// incompatibility between forks, test network and the main-net.
+///
+/// # Default
+///
+/// The default value is set to the mainnet
+///
+/// ```
+/// use wallet_crypto::config::{ProtocolMagic};
+///
+/// assert_eq!(ProtocolMagic::default(), ProtocolMagic::new(764824073));
+/// ```
+///
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub struct ProtocolMagic(u32);
+impl ProtocolMagic {
+    pub fn new(val: u32) -> Self { ProtocolMagic(val) }
+}
+impl cbor::CborValue for ProtocolMagic {
+    fn encode(&self) -> cbor::Value { cbor::CborValue::encode(&self.0) }
+    fn decode(value: cbor::Value) -> cbor::Result<Self> {
+        let v : u32 = cbor::CborValue::decode(value)?;
+        Ok(ProtocolMagic::new(v))
+    }
+}
+impl Default for ProtocolMagic {
+    fn default() -> Self { ProtocolMagic::new(764824073) }
+}
+
+/// Configuration for the wallet-crypto
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub struct Config {
+    pub protocol_magic: ProtocolMagic
+}
+impl Config {
+    pub fn new(protocol_magic: ProtocolMagic) -> Self {
+        Config {
+            protocol_magic: protocol_magic
+        }
+    }
+}
+impl Default for Config {
+    fn default() -> Self {
+        Config::new(ProtocolMagic::default())
+    }
+}

--- a/wallet-crypto/src/lib.rs
+++ b/wallet-crypto/src/lib.rs
@@ -7,6 +7,7 @@ extern crate rcw;
 mod crc32;
 mod util;
 mod merkle;
+pub mod config;
 pub mod hdwallet;
 pub mod paperwallet;
 pub mod address;

--- a/wallet-crypto/src/tx.rs
+++ b/wallet-crypto/src/tx.rs
@@ -7,6 +7,7 @@ use rcw::blake2b::Blake2b;
 use util::hex;
 use cbor;
 use cbor::{ExtendedResult};
+use config::{Config};
 
 use hdwallet::{Signature, XPub, XPrv};
 use address::{ExtendedAddr, SpendingData};
@@ -196,12 +197,11 @@ pub enum TxInWitness {
 }
 impl TxInWitness {
     /// create a TxInWitness from a given private key `XPrv` for the given transaction `Tx`.
-    pub fn new(key: &XPrv, tx: &Tx) -> Self {
+    pub fn new(cfg: &Config, key: &XPrv, tx: &Tx) -> Self {
         let txid = cbor::encode_to_cbor(&tx.id()).unwrap();
 
-        let mut vec = vec![ 0x01 // this is the tag for TxSignature
-                          , 0x1a, 0x2d, 0x96, 0x4a, 0x09 // this is the magic (serialised in cbor...)
-                          ];
+        let mut vec = vec![ 0x01 ]; // this is the tag for TxSignature
+        vec.extend_from_slice(&cbor::encode_to_cbor(&cfg.protocol_magic).unwrap());
         vec.extend_from_slice(&txid);
         TxInWitness::PkWitness(key.public(), key.sign(&vec))
     }
@@ -385,6 +385,7 @@ mod tests {
     use hdpayload;
     use hdwallet;
     use cbor;
+    use config::{Config};
 
     const SEED: [u8;hdwallet::SEED_SIZE] = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0];
 
@@ -478,29 +479,32 @@ mod tests {
 
     #[test]
     fn txinwitness_decode() {
+        let cfg = Config::default();
         let txinwitness : TxInWitness = cbor::decode_from_cbor(TX_IN_WITNESS).expect("to decode a `TxInWitness`");
         let tx : Tx = cbor::decode_from_cbor(TX).expect("to decode a `Tx`");
 
         let seed = hdwallet::Seed::from_bytes(SEED);
         let sk = hdwallet::XPrv::generate_from_seed(&seed);
 
-        assert!(txinwitness == TxInWitness::new(&sk, &tx));
+        assert!(txinwitness == TxInWitness::new(&cfg, &sk, &tx));
     }
 
     #[test]
     fn txinwitness_encode_decode() {
+        let cfg = Config::default();
         let tx : Tx = cbor::decode_from_cbor(TX).expect("to decode a `Tx`");
 
         let seed = hdwallet::Seed::from_bytes(SEED);
         let sk = hdwallet::XPrv::generate_from_seed(&seed);
 
-        let txinwitness = TxInWitness::new(&sk, &tx);
+        let txinwitness = TxInWitness::new(&cfg, &sk, &tx);
 
         assert!(cbor::hs::encode_decode(&txinwitness));
     }
 
     #[test]
     fn txinwitness_sign_verify() {
+        let cfg = Config::default();
         // create wallet's keys
         let seed = hdwallet::Seed::from_bytes(SEED);
         let sk = hdwallet::XPrv::generate_from_seed(&seed);
@@ -527,7 +531,7 @@ mod tests {
         // txout of this given transation
 
         // create a TxInWitness (i.e. sign the given transaction)
-        let txinwitness = TxInWitness::new(&sk, &tx);
+        let txinwitness = TxInWitness::new(&cfg, &sk, &tx);
 
         // check the address is the correct one
         assert!(txinwitness.verify_address(&ea));

--- a/wallet-wasm/src/lib.rs
+++ b/wallet-wasm/src/lib.rs
@@ -361,7 +361,10 @@ pub extern "C" fn wallet_tx_sign(cfg_ptr: *const c_uchar, cfg_size: usize, xprv_
 }
 
 #[no_mangle]
-pub extern "C" fn wallet_tx_verify(xpub_ptr: *const c_uchar, tx_ptr: *const c_uchar, tx_sz: usize, sig_ptr: *const c_uchar) -> i32 {
+pub extern "C" fn wallet_tx_verify(cfg_ptr: *const c_uchar, cfg_size: usize, xpub_ptr: *const c_uchar, tx_ptr: *const c_uchar, tx_sz: usize, sig_ptr: *const c_uchar) -> i32 {
+    let cfg_bytes : Vec<u8> = unsafe { read_data(cfg_ptr, cfg_size) };
+    let cfg_str = String::from_utf8(cfg_bytes).unwrap();
+    let cfg : Config = serde_json::from_str(cfg_str.as_str()).unwrap();
     let xpub = unsafe { read_xpub(xpub_ptr) };
     let signature = unsafe { read_signature(sig_ptr) };
 
@@ -370,7 +373,7 @@ pub extern "C" fn wallet_tx_verify(xpub_ptr: *const c_uchar, tx_ptr: *const c_uc
 
     let txinwitness = tx::TxInWitness::PkWitness(xpub, signature);
 
-    if txinwitness.verify_tx(&tx) { 0 } else { -1 }
+    if txinwitness.verify_tx(&cfg, &tx) { 0 } else { -1 }
 }
 
 mod jrpc {


### PR DESCRIPTION
add support for a configuration object allowing to set the `protocol_magic` dynamically.

fix #39 